### PR TITLE
Add `getCollection()` client method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@poprank/sdk",
-    "version": "1.0.10",
+    "version": "1.0.11",
     "description": "PopRank's NFT rarity and aesthetic ranking logic",
     "publishConfig": {
         "access": "public",

--- a/src/client/collections.ts
+++ b/src/client/collections.ts
@@ -5,7 +5,7 @@ import { CollectionWithSeen } from '../types/collections';
 import { APIResponse } from '../types/general';
 import { TraitOverview } from '../types/traits';
 
-/** Get all collections. If `name` is provided, then the collection is updated on the server, before the full collections response is sent */
+/** Get all collections. If `slug` is provided, then the collection is updated on the server, before the full collections response is sent. */
 export const getCollections = async (slug?: string, player?: string, serverUrl = SERVER_IP): Promise<CollectionWithSeen[]> => {
     try {
         const res = (await axios.get<APIResponse<CollectionWithSeen[]>>(`${serverUrl}/collections`, { params: { slug, player } })).data;
@@ -18,6 +18,27 @@ export const getCollections = async (slug?: string, player?: string, serverUrl =
 
     } catch (e) {
         throw 'Failed to get collections';
+    }
+};
+
+/**
+ * Get the `Collection` object that corresponds with the provided `slug`. The
+ * collection is updated on PopRank's server before response, so this method
+ * effectively doubles as a data refresh.
+ * @summary Get a collection.
+ * @param slug The collection identifier used in the PopRank collection page URL.
+ */
+export const getCollection = async (slug: string): Promise<CollectionWithSeen[]> => {
+    try {
+        const res = (await axios.get<APIResponse<CollectionWithSeen[]>>(`${SERVER_IP}/collections/${slug}`, { params: { slug } })).data;
+
+        if (!res.success) {
+            throw new Error(res.data);
+        }
+
+        return res.data;
+    } catch (e) {
+        throw 'Failed to get collection';
     }
 };
 

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,4 +1,4 @@
-export { getCollections, getCollectionOverview, getNumOwners } from './collections';
+export { getCollection, getCollections, getCollectionOverview, getNumOwners } from './collections';
 export { getDiscordUsername } from './discordUsername';
 export { getPlayerLeaderboard } from './leaderboard';
 export { getNft, getNfts } from './nfts';


### PR DESCRIPTION
The `getCollection()` method hits the `/collections/:slug` API endpoint