### PR TITLE
Improve API Client DX

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@poprank/sdk",
-    "version": "1.0.13",
-    "description": "PopRank's NFT rarity and aesthetic ranking logic",
+    "version": "1.0.14",
+    "description": "PopRank API client and types",
     "publishConfig": {
         "access": "public",
         "registry": "https://registry.npmjs.org/"

--- a/src/client.ts
+++ b/src/client.ts
@@ -124,7 +124,7 @@ export class PopRankClient {
      * @param slug The collection identifier used in the PopRank collection page URL.
      * @param player Although optional, required to validate the round.
      */
-    async getNFTPair(slug: string, player?: string): Promise<Pair> {
+    async getNftPair(slug: string, player?: string): Promise<Pair> {
         const response = (await this.client.get<APIResponse<Pair>>(
             `/nfts/${slug}/double`,
             { params: { player } },

--- a/src/types/nfts.ts
+++ b/src/types/nfts.ts
@@ -95,3 +95,32 @@ export interface NftWithRatedTraits extends NftInit {
  * for head-to-head rounds
  */
 export type Pair = [Nft, Nft];
+
+/**
+ * Options object to pass into `getNfts()`.
+ */
+export interface GetNftsOptions {
+    readonly offset?: number;
+    readonly count?: number;
+    readonly asc?: boolean;
+    readonly sortBy?: SortBy;
+    readonly traitFilters: string[];
+    readonly minAesthetic?: number;
+    readonly maxAesthetic?: number;
+    readonly minRarityTraitSum?: number;
+    readonly maxRarityTraitSum?: number;
+    readonly minPrice?: number;
+    readonly maxPrice?: number;
+    readonly name?: string;
+    readonly user?: string;
+    readonly onlyUserTokens?: boolean;
+}
+
+/**
+ * Options object to pass into `getNft()`.
+ */
+export interface GetNftOptions {
+    readonly price?: boolean;
+    readonly rank?: boolean;
+    readonly traits?: boolean;
+}


### PR DESCRIPTION
- Use an optional params object for `getNfts()` and `getNft()`
- Improve JSDoc comments
- Standardize usage of "Nft" over "NFT" in `getNft()`, `getNfts()`, and `getNftPair()` https://stackoverflow.com/questions/15526107/acronyms-in-camelcase#:~:text=When%20using%20acronyms%2C%20use%20Pascal,in%20identifiers%20or%20parameter%20names.